### PR TITLE
Fix an Out-of-Bound read in SplitBasicBlocks

### DIFF
--- a/llvm/lib/Transforms/Obfuscation/SplitBasicBlocks.cpp
+++ b/llvm/lib/Transforms/Obfuscation/SplitBasicBlocks.cpp
@@ -85,7 +85,7 @@ void SplitBasicBlock::split(Function *f) {
     }
 
     // Check splitN and current BB size
-    if ((size_t)splitN > curr->size()) {
+    if ((size_t)splitN >= curr->size()) {
       splitN = curr->size() - 1;
     }
 


### PR DESCRIPTION
```
    // Check splitN and current BB size
    if ((size_t)splitN > curr->size()) {
      splitN = curr->size() - 1;
    }

    // Generate splits point
    std::vector<int> test;
    for (unsigned i = 1; i < curr->size(); ++i) {
      test.push_back(i);
    }

    // Shuffle
    if (test.size() != 1) {
      shuffle(test);
      std::sort(test.begin(), test.begin() + splitN);
    }

    // Split
    BasicBlock::iterator it = curr->begin();
    BasicBlock *toSplit = curr;
    int last = 0;
    for (int i = 0; i < splitN; ++i) {
      for (int j = 0; j < test[i] - last; ++j) {
        ++it;
      }
      last = test[i];
      if(toSplit->size() < 2)
        continue;
      toSplit = toSplit->splitBasicBlock(it, toSplit->getName() + ".split");
    }
```
如果 splitN 和 curr->size() 的大小是相同的，那么在后续代码 Spilt 的 for 循环中，会对 std::vector<int> test 进行越界读。

假设 spiltN 是 2（splitN 的取值范围是 [2,10]），当前基本块的指令数量也为 2（即 curr->size() 为2），那么在 Generate splits point 后，std::vector<int> test 只含有一个元素 1。而在 Split 的 for 循环中，i 的取值范围是 [0,1]，因此在以 i 为下标访问 test 时会访问 test[1]，但是 test 只含有一个元素，所以会发生越界读。